### PR TITLE
add endpoint to get corona data per country and datasource

### DIFF
--- a/utils/functions.js
+++ b/utils/functions.js
@@ -41,7 +41,52 @@ const countryFilter = (allowedCountry) => {
   return coronaData => coronaData.country == allowedCountry.toUpperCase()
 }
 
+const countryDatasourceReducer = (intermediateResult, coronaData) => {
+  const {country, url, ...otherCoronaData} = coronaData
+  const getOrZero = number => undefined === number ? 0 : number
+
+  let newResult = intermediateResult
+
+  if (undefined === intermediateResult[country]) {
+    newResult[country] = {}
+    newResult[country][url] = {
+      cases: getOrZero(otherCoronaData.cases),
+      recovered: getOrZero(otherCoronaData.recovered),
+      deaths: getOrZero(otherCoronaData.deaths),
+      active: getOrZero(otherCoronaData.active),
+      rating: getOrZero(coronaData.rating),
+      population: getOrZero(otherCoronaData.population),
+      coordinates: getOrZero(otherCoronaData.coordinates)
+    }
+    return newResult
+  }
+
+  if (undefined === intermediateResult[country][url]) {
+    newResult[country][url] = {
+      cases: getOrZero(otherCoronaData.cases),
+      recovered: getOrZero(otherCoronaData.recovered),
+      deaths: getOrZero(otherCoronaData.deaths),
+      active: getOrZero(otherCoronaData.active),
+      rating: getOrZero(coronaData.rating),
+      population: getOrZero(otherCoronaData.population),
+      coordinates: getOrZero(otherCoronaData.coordinates)
+    }
+    return newResult
+  }
+
+  let intermediateForCountryAndDatasource = newResult[country][url]
+  intermediateForCountryAndDatasource.cases += getOrZero(otherCoronaData.cases)
+  intermediateForCountryAndDatasource.active += getOrZero(otherCoronaData.active)
+  intermediateForCountryAndDatasource.recovered += getOrZero(otherCoronaData.recovered)
+  intermediateForCountryAndDatasource.deaths += getOrZero(otherCoronaData.deaths)
+  intermediateForCountryAndDatasource.population += getOrZero(otherCoronaData.population)
+  newResult[country][url] = intermediateForCountryAndDatasource
+
+  return newResult
+}
+
 exports.readJsonFileSync = readJsonFileSync
 exports.coronaDataMapper = coronaDataMapper
 exports.ratingFilter = ratingFilter
 exports.countryFilter = countryFilter
+exports.countryDatasourceReducer = countryDatasourceReducer


### PR DESCRIPTION
Sieht gut aus. Beispielsweise die UK results:

```
{
  "GBR": {
    "https://github.com/CSSEGISandData/COVID-19": {
      "cases": 4014,
      "recovered": 67,
      "deaths": 178,
      "active": 3769,
      "rating": 0.4878048780487805,
      "population": 64801646,
      "coordinates": [
        -2.3644,
        49.3723
      ]
    },
    "https://www.arcgis.com/sharing/rest/content/items/b684319181f94875a6879bbc833ca3a6/data": {
      "cases": 3246,
      "recovered": 0,
      "deaths": 0,
      "active": 3246,
      "rating": 0.4146341463414634,
      "population": 29440832,
      "coordinates": [
        0.12030826146707341,
        51.54832672819592
      ]
    }
  }
}
```

@brauls @martiL 